### PR TITLE
Travis CI tweaks

### DIFF
--- a/.travis.maven.settings.xml
+++ b/.travis.maven.settings.xml
@@ -1,0 +1,17 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <interactiveMode>false</interactiveMode>
+
+  <servers>
+    <server>
+      <id>jboss-snapshots-repository</id>
+      <username>${env.NEXUS_DEPLOY_USERNAME}</username>
+      <password>${env.NEXUS_DEPLOY_PASSWORD}</password>
+    </server>
+  </servers>
+
+</settings>
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,23 @@ language: java
 jdk:
   - oraclejdk8
 
+env:
+  global:
+    - secure: "T4m4w+yL5sOtqaTcOm6lMjBHlPTLL//ihCCsC9rsMoLlNusW2tRieNCkGRikGPrQBwkmqtDXi8EPiypSarQ6q8jOf34sKYMbyNceIjndRkch0wyQk4+tQDAmoBAxUdO157eQw8vYb4c9ox8hQAVxVKynH7I/7mLYfv00nTr4zY8="
+    - secure: "DKej+NuWNHavxLML0KvFZwPEKZ2fEHIG+kGMaUrYjVp9lR3TBwszb6kVJicbF6oCs/qYl+EqI/WJy+45CyE+aEo3t5qjpyg2wrK0EEZ99PEuq9kC9TrGucbGpxGdyqVdyl7VnSaYqEdpt5PXpunDzyL/fREyNRVep6qMIBz1FTs="
+  
+branches:
+  only:
+    - master
+
 install:
   - mvn -version -B
 
 script:
-  - mvn -fae clean install
+  - mvn -fae install | grep -vF "Downloading:" | grep -vF "Downloaded:"
+
+after_success:
+  - test "${TRAVIS_PULL_REQUEST}" = "false" && mvn -s .travis.maven.settings.xml -DskipTests=true deploy
 
 notifications:
-  email: false
-
+  email: gbrown@redhat.com


### PR DESCRIPTION
@objectiser, this is similar to how I set up Artificer -- seems to be working well.  Notes:

1.) It's using my `brmeyer` account to deploy snapshots to Nexus.  The `NEXUS_DEPLOY_USERNAME` and `NEXUS_DEPLOY_PASSWORD` bits used in settings.xml match up with the `eng/global/secure` values in `.travis.yml` -- you have to use the Travis CLI to encrypt, for example, "NEXUS_DEPLOY_USERNAME=brmeyer".
2.) `test "${TRAVIS_PULL_REQUEST}" = "false"` prevents snapshot deployment when the job is run against a pull request, if you have that enabled in Travis.
3.) If you haven't already, the `io.scepta` group may need added/approved in JBoss Nexus.
